### PR TITLE
restorable MML models and PEFT integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.X.X (XX/XX/2025)
+
+### Bug fixes
+ - fixed incorrect handling of hydra choices in CONTINUE mode
+
 ## 1.0.4 (05/02/2025):
 This patch transitions the testing strategy from GPU based to purely CPU tests. 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Features
  - persistent model checkpoints now only rely on the MML format (instead of previously using the lightning format)
-
-### Features
  - improved error handling with interrupted dataset creation, which gives clear instructions how to resolve
+ - new config group `peft`, which offers to inject `huggingface/peft` adapters into models and reduce train parameters
 
 ### Bug fixes
  - fixed incorrect handling of hydra choices in CONTINUE mode
+ - fixed .env loading for non default system 
 
 ## 1.0.4 (05/02/2025):
 This patch transitions the testing strategy from GPU based to purely CPU tests. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 1.X.X (XX/XX/2025)
+## 1.1.0 (XX/XX/2025)
+
+### Features
+ - persistent model checkpoints now only rely on the MML format (instead of previously using the lightning format)
 
 ### Bug fixes
  - fixed incorrect handling of hydra choices in CONTINUE mode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - improved error handling with interrupted dataset creation, which gives clear instructions how to resolve
  - new config group `peft`, which offers to inject `huggingface/peft` adapters into models and reduce train parameters
 
+### API changes
+ - changed the `logging` defaults for the `sys=cluster` configuration to improve readability 
+
 ### Bug fixes
  - fixed incorrect handling of hydra choices in CONTINUE mode
  - fixed .env loading for non default system 

--- a/docs/source/cli/hpo.rst
+++ b/docs/source/cli/hpo.rst
@@ -3,11 +3,12 @@ hpo
 
 The hpo config group controls hyperparameter optimization searches. It is triggered by the ``--multirun`` flag when
 invoking an mml experiment (see `hydra's documentation <https://hydra.cc/docs/tutorials/basic/running_your_app/multi-run/>`_).
-If using an:class:`~mml.interactive.planning.MMLJobDescription` there is the ``multirun`` boolean flag.
 
-``use_best_params``
+.. note::
+    If using an :class:`~mml.interactive.planning.MMLJobDescription` there is the ``multirun`` boolean flag.
 
-:doc:`/hpo`
+To leverage the results of a hyperparameter run the CLI kwarg ``use_best_params`` can be used. See
+:ref:`main-config-file` for its documentation. Also note the overview given at :doc:`/hpo`.
 
 
 default

--- a/docs/source/cli/overview.rst
+++ b/docs/source/cli/overview.rst
@@ -106,6 +106,8 @@ The final configuration can be displayed with the help of hydra-flags
    tta
    tune
 
+.. _main-config-file:
+
 main config file
 ~~~~~~~~~~~~~~~~
 

--- a/docs/source/cli/overview.rst
+++ b/docs/source/cli/overview.rst
@@ -62,6 +62,7 @@ This following is a list of ``mml`` config groups. To see all available current 
   * :doc:`metrics` - metrics to measure model performance
   * :doc:`mode` - central component defining the scheduler and other corresponding runtime settings
   * :doc:`optimizer` - network training optimizer
+  * :doc:`peft` - parameter efficient finetuning
   * :doc:`preprocessing` - image preprocessing pipeline (applied while training and predicting)
   * :doc:`reuse` - determines the reuse of previous results as well as clean up of intermediates
   * :doc:`sampling` - sets sampling strategy
@@ -93,6 +94,7 @@ The final configuration can be displayed with the help of hydra-flags
    metrics
    mode
    optimizer
+   peft
    preprocessing
    remove
    reuse

--- a/docs/source/cli/peft.rst
+++ b/docs/source/cli/peft.rst
@@ -1,0 +1,20 @@
+peft
+====
+
+The ``peft`` config group manages ``parameter efficient finetuning`` strategies. Note that this feature is still in beta
+phase. By default (``peft=none``) no peft is performed. If activated the model will get injected some adapters that will
+be trainable but all other backbone parameters will be frozen. Note that model heads always remain trainable. See
+:class:`~mml.core.models.torch_base.BaseModel` for implementation details and
+`huggingface/peft <https://huggingface.co/docs/peft/index>`_ for the details of the library that ``MML`` leverages.
+Note that once peft is activated on a model this process is not reversible, any loading of the model will always use
+the originally configured peft method. The following example gives a good overview on som eof the configuration options:
+
+lora
+~~~~
+
+Low-Rank Adaptation (LoRA) is a PEFT method that decomposes a large matrix into two smaller low-rank matrices in the
+some model layers. This drastically reduces the number of parameters that need to be fine-tuned.
+Please refer to the `docs <https://huggingface.co/docs/peft/main/en/package_reference/lora#peft.LoraConfig>`_ for all
+config options of LoRA.
+
+.. autoyaml:: peft/lora.yaml

--- a/docs/source/cli/tta.rst
+++ b/docs/source/cli/tta.rst
@@ -8,9 +8,15 @@ predictions are merged. The augmentations are loaded through the
 :class:`~mml.core.data_loading.augmentations.kornia.KorniaAugmentationModule` that can deal with any (unnested) list of
 `kornia <https://kornia.readthedocs.io/en/latest/augmentation.html>`_ augmentations.
 Note that tta is only active during testing and predicting with models - not during training nor validation.
-The following example gives a good overview on the configuration options:
+The following examples give a good overview on the configuration options:
 
 rotate
 ~~~~~~
 
 .. autoyaml:: tta/rotate.yaml
+
+
+crop
+~~~~
+
+.. autoyaml:: tta/crop.yaml

--- a/docs/source/hpo.rst
+++ b/docs/source/hpo.rst
@@ -3,7 +3,10 @@ Hyperparameter optimization
 
 
 Attaching ``--multirun`` to your command will start the job in hpo mode. Note that multirun does not offer
-the ``continue`` (see :doc:`usage`) functionality!
+the ``continue`` (see :ref:`continue-option`) functionality!
+
+.. note::
+    More details on the config options can be found at :doc:`cli/hpo`.
 
 Gridsearch
 ----------
@@ -30,7 +33,8 @@ usage
 
 Create a config file defining your search space for the hyperparameters at ``configs/search_space``.
 And afterwards call the program as follows (make sure your mode has a return value to optimize using
-:class:`~mml.core.scripts.schedulers.base_scheduler.AbstractBaseScheduler`'s ``return_value``).
+:class:`~mml.core.scripts.schedulers.base_scheduler.AbstractBaseScheduler`'s
+:attr:`~mml.core.scripts.schedulers.base_scheduler.AbstractBaseScheduler.return_value`).
 
 .. code-block:: bash
 

--- a/plugins/lsf/CHANGELOG.md
+++ b/plugins/lsf/CHANGELOG.md
@@ -5,8 +5,13 @@ All notable changes to this plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.5.2 (XX/XX/2025)
-Allows to import ``LSFSubmissionRequirements`` and ``LSFJobRunner`` from top level of the module.
+## 0.6.0 (XX/XX/2025)
+Adds a bunch of new features to the `LSFRunner`
+
+### Features
+ - `dump` and `load` runners to be independent of a single execution and increase persistency
+ - job management was extended by `kill` and `peek` methods
+ - improved verbosity and documentation
 
 ### Bug fixes
  - fixed incorrect handling of hydra choices in CONTINUE mode

--- a/plugins/lsf/CHANGELOG.md
+++ b/plugins/lsf/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.2 (XX/XX/2025)
+
+### Bug fixes
+ - fixed incorrect handling of hydra choices in CONTINUE mode
+
 ## 0.5.1 (12/19/2024):
 Public release version.
 

--- a/plugins/lsf/setup.cfg
+++ b/plugins/lsf/setup.cfg
@@ -38,6 +38,7 @@ zip_safe = no
 include_package_data = True
 install_requires =
     mml-core>=1.0.0
+    dacite
 
 [options.entry_points]
 mml.plugins =

--- a/plugins/lsf/src/mml_lsf/__init__.py
+++ b/plugins/lsf/src/mml_lsf/__init__.py
@@ -4,9 +4,6 @@
 # SPDX-License-Identifier: MIT
 #
 
-from mml_lsf.requirements import LSFSubmissionRequirements
-from mml_lsf.runner import LSFJobRunner
-
 VERSION = (0, 5, 1)
 __version__ = ".".join(map(str, VERSION))
 __all__ = ["__version__", "LSFJobRunner", "LSFSubmissionRequirements"]

--- a/plugins/lsf/src/mml_lsf/activate.py
+++ b/plugins/lsf/src/mml_lsf/activate.py
@@ -4,8 +4,18 @@
 # SPDX-License-Identifier: MIT
 #
 
+from pathlib import Path
+
 from mml_lsf.workers import check_lsf_workers
 
+from mml.core.data_loading.file_manager import MMLFileManager
 from mml.core.scripts.schedulers.base_scheduler import AFTER_SCHEDULER_INIT_HOOKS
 
 AFTER_SCHEDULER_INIT_HOOKS.append(check_lsf_workers)
+MMLFileManager.add_assignment_path(
+    obj_cls=None,
+    key="lsf_jobs",
+    path=Path("PROJ_PATH") / "LSF" / "FILE_NAME",
+    enable_numbering=False,
+    reusable=False,
+)

--- a/plugins/lsf/src/mml_lsf/workers.py
+++ b/plugins/lsf/src/mml_lsf/workers.py
@@ -64,7 +64,8 @@ def check_lsf_workers(scheduler: AbstractBaseScheduler) -> None:
     if scheduler.continue_status:
         warnings.warn(
             f"LSF cluster plugin detected CONTINUE run. This means system check will be skipped and CPUs will "
-            f"be capped by at least {DEFAULT_CPU_CAP}.")
+            f"be capped by at least {DEFAULT_CPU_CAP}."
+        )
     else:
         try:
             hydra_cfg = HydraConfig.get()

--- a/plugins/similarity/CHANGELOG.md
+++ b/plugins/similarity/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.X.X (XX/XX/2025):
+### Features
+ - slightly improve loading logic of tuned model to generalize better
+
 ## 0.5.3 (03/25/2025):
 Fix `fed` distance fim loading with new default value for `torch.load` in torch 2.6
 

--- a/plugins/similarity/src/mml_similarity/scripts/fed_scheduler.py
+++ b/plugins/similarity/src/mml_similarity/scripts/fed_scheduler.py
@@ -13,6 +13,7 @@ from mml_similarity.scripts.fisher import compute_fisher_information_embedding, 
 from mml_similarity.scripts.vector_distances import compute_task_distance
 from omegaconf import DictConfig
 
+from mml.core.models.torch_base import BaseModel
 from mml.core.scripts.exceptions import MMLMisconfigurationException
 from mml.core.scripts.utils import LearningPhase
 
@@ -108,9 +109,9 @@ class FEDScheduler(AbstractTaskDistanceScheduler):
             )
         # loading model, need only torch.nn.Module not lightning module -> can drop this information
         logger.debug("Loading model...")
-        path = task_struct.paths["fc_tuned"]
-        model = self.create_model([task_struct]).model
-        model.load_checkpoint(param_path=path)
+        model = BaseModel.load_checkpoint(param_path=task_struct.paths["fc_tuned"])
+        if task_name not in model.heads:
+            raise RuntimeError(f"No head for task {task_name} in tuned model @ {task_struct.paths['fc_tuned']}.")
         logger.debug("Preparing data...")
         data_module = self.create_datamodule(task_structs=task_struct)
         data_module.setup(stage="fit")

--- a/plugins/tasks/CHANGELOG.md
+++ b/plugins/tasks/CHANGELOG.md
@@ -10,6 +10,7 @@ ToDo summary
 
 ### Bug fixes
  - fixes issue #16, an incorrect download url in the idle_action_recognition task
+ - fix creation issue with ISIC20 task because of incorrect iterator
 
 ## 0.6.0 (12/19/2024):
 Public release version after last license compatibility fixes. Includes a renaming from mml-data to mml-tasks!

--- a/plugins/tasks/src/mml_tasks/creators/classification/isic20.py
+++ b/plugins/tasks/src/mml_tasks/creators/classification/isic20.py
@@ -103,12 +103,12 @@ def create_task(dset_path: Path):
                 Modality.CLASS: int(train_annotation.at[img_path.stem]),
             }
         )
-    test_iterator = []
+    unlabeled_iterator = []
     for img_path in (dset_path / DataKind.TESTING_DATA / "ISIC_2020_Test_Input").iterdir():
         if img_path.suffix != ".jpg":
             continue
-        test_iterator.append({Modality.SAMPLE_ID: img_path.stem, Modality.IMAGE: img_path})
-    task.find_data(train_iterator=train_iterator, test_iterator=test_iterator, idx_to_class=idx_to_class)
+        unlabeled_iterator.append({Modality.SAMPLE_ID: img_path.stem, Modality.IMAGE: img_path})
+    task.find_data(train_iterator=train_iterator, unlabeled_iterator=unlabeled_iterator, idx_to_class=idx_to_class)
     task.split_folds(n_folds=5, ensure_balancing=True)
     # because of varying sizes and high resolution inference takes multiple hours, set stats instead
     task.set_stats(

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,6 +74,7 @@ install_requires =
     humanize
     psrcal==0.0.2
     quapy==0.1.9
+    peft
 
 [options.extras_require]
 dev =

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ install_requires =
     torch
     torchvision
     torchmetrics
-    segmentation-models-pytorch==0.3.3
+    segmentation-models-pytorch==0.5.0
     plotly
     statsmodels==0.13.5
     matplotlib

--- a/src/mml/__main__.py
+++ b/src/mml/__main__.py
@@ -246,9 +246,7 @@ def wrapped_mml() -> float:
             except ValueError:
                 # fallback, should not happen, but to prevent any future break or other misuse
                 mode_to_log = "UNKNOWN"
-        logger.info(
-            f"Started MML {mml.__version__} on Python {platform.python_version()} with mode {mode_to_log}."
-        )
+        logger.info(f"Started MML {mml.__version__} on Python {platform.python_version()} with mode {mode_to_log}.")
         logger.info(f"Plugins loaded: {list(mml.core.scripts.utils.MML_PLUGINS_LOADED.keys())}")
         # instantiate notifiers
         all_notifiers: List[BaseNotifier] = [

--- a/src/mml/configs/augmentations/baseline224.yaml
+++ b/src/mml/configs/augmentations/baseline224.yaml
@@ -1,0 +1,18 @@
+# @package augmentations
+
+# LICENSE HEADER MANAGED BY add-license-header
+#
+# SPDX-FileCopyrightText: Copyright 2024 German Cancer Research Center (DKFZ) and contributors.
+# SPDX-License-Identifier: MIT
+#
+
+normalization: imagenet  # image_net mean and std values are used
+cpu:
+  backend: albumentations
+  pipeline:
+    - name: RandomResizedCrop
+      size: [224,224]
+      p: 1.0
+    - name: HorizontalFlip
+      p: 0.5
+gpu: { }

--- a/src/mml/configs/augmentations/baseline224.yaml
+++ b/src/mml/configs/augmentations/baseline224.yaml
@@ -2,7 +2,7 @@
 
 # LICENSE HEADER MANAGED BY add-license-header
 #
-# SPDX-FileCopyrightText: Copyright 2024 German Cancer Research Center (DKFZ) and contributors.
+# SPDX-FileCopyrightText: Copyright 2025 German Cancer Research Center (DKFZ) and contributors.
 # SPDX-License-Identifier: MIT
 #
 

--- a/src/mml/configs/config_mml.yaml
+++ b/src/mml/configs/config_mml.yaml
@@ -12,7 +12,6 @@
 # specify here default training configuration
 defaults:
   - _self_
-  - sys: local
   - tasks: none
   - arch: timm
   - optimizer: adam
@@ -26,6 +25,7 @@ defaults:
   - preprocessing: default
   - augmentations: default
   - logging: log
+  - sys: local                # sys after logging so that colors can be deactivated
   - sampling: full
   - search_space: none
   - hpo: default
@@ -34,7 +34,7 @@ defaults:
   - loaders: default
   - tta: none
   - peft: none
-  - mode: info  # is done very last to allow overriding above defaults
+  - mode: info                # is done very last to allow overriding above defaults
   - override hydra/hydra_logging: col_stdout
   - override hydra/help: mml_help
 

--- a/src/mml/configs/config_mml.yaml
+++ b/src/mml/configs/config_mml.yaml
@@ -33,6 +33,7 @@ defaults:
   - compile: default
   - loaders: default
   - tta: none
+  - peft: none
   - mode: info  # is done very last to allow overriding above defaults
   - override hydra/hydra_logging: col_stdout
   - override hydra/help: mml_help

--- a/src/mml/configs/hydra/job_logging/stdout_and_file.yaml
+++ b/src/mml/configs/hydra/job_logging/stdout_and_file.yaml
@@ -1,0 +1,28 @@
+# @package hydra.job_logging
+
+# LICENSE HEADER MANAGED BY add-license-header
+#
+# SPDX-FileCopyrightText: Copyright 2024 German Cancer Research Center (DKFZ) and contributors.
+# SPDX-License-Identifier: MIT
+#
+
+# python logging configuration for tasks
+version: 1
+formatters:
+  simple:
+    format: '[%(asctime)s][%(name)s][%(levelname)s] - %(message)s'
+handlers:
+  console:
+    class: logging.StreamHandler
+    formatter: simple
+    stream: ext://sys.stdout
+  file:
+    class: logging.FileHandler
+    formatter: simple
+    # relative to the job log directory
+    filename: exp.log
+root:
+  level: INFO
+  handlers: [ console, file ]
+
+disable_existing_loggers: false

--- a/src/mml/configs/logging/log.yaml
+++ b/src/mml/configs/logging/log.yaml
@@ -10,6 +10,7 @@ defaults:
   - exp_logger: tensorboard
   - render: colorlog
   - notifier: none
+
 ###
 # default: True
 #  - enables the highlight text feature of the base AbstractBaseScheduler, colouring specific parts of logs

--- a/src/mml/configs/logging/render/no_col.yaml
+++ b/src/mml/configs/logging/render/no_col.yaml
@@ -7,7 +7,7 @@
 #
 
 defaults:
-  - override /hydra/job_logging: col_stdout_and_file
+  - override /hydra/job_logging: stdout_and_file
 
 logging:
   render:

--- a/src/mml/configs/mode/train.yaml
+++ b/src/mml/configs/mode/train.yaml
@@ -80,8 +80,8 @@ mode:
   #  - see the ``suggest`` plugin for an example how to generate blueprints
   use_blueprint: False
   ###
-  # default: [arch,augmentations,cbs,loss,lr_scheduler,mode,optimizer,preprocessing,sampling,trainer,tta,tune]
-  #  - these pipeline keys will be for one stored as a documentation of the training pipeline
+  # default: [arch,augmentations,cbs,loss,lr_scheduler,mode,optimizer,peft,preprocessing,sampling,trainer,tta,tune]
+  #  - these pipeline keys will be stored as a documentation of the training pipeline
   #  - on the other hand if using a blueprint, only these keys will be loaded to override the given sections
   pipeline_keys:
     - 'arch'
@@ -91,6 +91,7 @@ mode:
     - 'lr_scheduler'
     - 'mode'
     - 'optimizer'
+    - 'peft'
     - 'preprocessing'
     - 'sampling'
     - 'trainer'

--- a/src/mml/configs/peft/lora.yaml
+++ b/src/mml/configs/peft/lora.yaml
@@ -1,0 +1,29 @@
+# @package peft
+
+# LICENSE HEADER MANAGED BY add-license-header
+#
+# SPDX-FileCopyrightText: Copyright 2025 German Cancer Research Center (DKFZ) and contributors.
+# SPDX-License-Identifier: MIT
+#
+
+# used to set Parameter Efficient FineTuning
+# see https://github.com/huggingface/peft for detailed instructions
+
+
+_target_: peft.LoraConfig
+###
+# default: 8
+#  - LoRa attention dimension (the "rank")
+r: 8
+###
+# default: auto
+#  - list of module names or regex expression of the module names to replace with LoRA
+#  - for example, ['q', 'v'] or '.*decoder.*(SelfAttention|EncDecAttention).*(q|v)$'
+#  - if "auto" will find all compatible layers
+target_modules: auto
+###
+# default: null
+#  - the names of the modules to not apply the adapter. When passing a string, a regex match will be performed.
+#  - when passing a list of strings, either an exact match will be performed
+#  - or it is checked if the name of the module ends with any of the passed strings
+exclude_modules: null

--- a/src/mml/configs/peft/none.yaml
+++ b/src/mml/configs/peft/none.yaml
@@ -1,0 +1,12 @@
+# @package peft
+
+# LICENSE HEADER MANAGED BY add-license-header
+#
+# SPDX-FileCopyrightText: Copyright 2025 German Cancer Research Center (DKFZ) and contributors.
+# SPDX-License-Identifier: MIT
+#
+
+# used to set Parameter Efficient FineTuning
+# see https://github.com/huggingface/peft for detailed instructions
+
+_target_: null

--- a/src/mml/configs/sys/cluster.yaml
+++ b/src/mml/configs/sys/cluster.yaml
@@ -6,6 +6,9 @@
 # SPDX-License-Identifier: MIT
 #
 
+defaults:
+  - override /hydra/job_logging: stdout_and_file
+
 ###
 # default: ${oc.env:MML_CLUSTER_DATA_PATH}
 #  - path to data folder
@@ -26,3 +29,5 @@ trainer:
   # default: False
   #  - disable progress bar for detached system
   enable_progress_bar: False
+logging:
+  highlight_text: False

--- a/src/mml/configs/tta/crop.yaml
+++ b/src/mml/configs/tta/crop.yaml
@@ -1,0 +1,45 @@
+# @package tta
+
+# LICENSE HEADER MANAGED BY add-license-header
+#
+# SPDX-FileCopyrightText: Copyright 2024 German Cancer Research Center (DKFZ) and contributors.
+# SPDX-License-Identifier: MIT
+#
+
+###
+# default: mean
+#  - sets the mode of the :class:`~mml.core.models.merger.PredictionMerger`
+#  - currently only "mean" is supported
+mode: mean
+###
+# default: ???
+#  - central parameter to specify output size
+#  - expects two ints
+size: ???
+variations:
+  ###
+  # default: {name: RandomHorizontalFlip, p: 0.0}
+  #  - perform no augmentation
+  identity:
+    - name: RandomHorizontalFlip
+      p: 0.0
+  ###
+  # default: {name: RandomResizedCrop, p: 1.0, size: ${tta.size}}
+  #  - crop a part of the image
+  crop1:
+    - name: RandomResizedCrop
+      size: ${tta.size}
+      p: 1.0
+  ###
+  # default: {name: RandomResizedCrop, p: 1.0, size: ${tta.size}}
+  #  - crop a part of the image
+  crop2:
+    - name: RandomResizedCrop
+      size: ${tta.size}
+      p: 1.0
+  ###
+  # default: {name: RandomResizedCrop, p: 1.0, size: ${tta.size}}
+  #  - crop a part of the image
+  crop3:
+    - size: ${tta.size}
+      p: 1.0

--- a/src/mml/core/data_loading/file_manager.py
+++ b/src/mml/core/data_loading/file_manager.py
@@ -14,7 +14,6 @@ from typing import Dict, List, Optional, Union
 import ijson
 import orjson
 import torch
-from lightning.pytorch.callbacks import ModelCheckpoint
 from omegaconf import Container, DictConfig
 
 from mml.core.data_loading.task_description import (
@@ -40,7 +39,7 @@ REUSABLE_NUMBER_TAG = "#"
 # default strategies to determine file paths for certain computed artefacts
 # key : (type, path, enable_numbering, reusable)
 DEFAULT_ASSIGNMENTS = {
-    "parameters": (ModelCheckpoint, Path("PROJ_PATH") / "PARAMETERS" / "TASK_NAME" / "model.pth", True, True),
+    "parameters": (torch.nn.Module, Path("PROJ_PATH") / "PARAMETERS" / "TASK_NAME" / "model.mml", True, True),
     "img_examples": (None, Path("PROJ_PATH") / "IMG_EXAMPLES" / "TASK_NAME" / "examples.png", True, False),
     "blueprint": (Container, Path("PROJ_PATH") / "BLUEPRINTS" / "TASK_NAME" / "blueprint.yaml", True, True),
     "pipeline": (Container, Path("PROJ_PATH") / "PIPELINES" / "TASK_NAME" / "pipeline.yaml", True, True),

--- a/src/mml/core/data_loading/lightning_datamodule.py
+++ b/src/mml/core/data_loading/lightning_datamodule.py
@@ -34,11 +34,11 @@ logger = logging.getLogger(__name__)
 
 class MultiTaskDataModule(lightning.LightningDataModule):
     """
-    This class wraps one or multiple :class:`~mml.core.data_loading.task_dataset.TaskDataset`s for lightning.
-    Given the respective :class:`~mml.core.data_loading.task_structs.TaskStruct`s it takes care of setting up all
+    This class wraps one or multiple :class:`~mml.core.data_loading.task_dataset.TaskDataset` s for lightning.
+    Given the respective :class:`~mml.core.data_loading.task_structs.TaskStruct` s it takes care of setting up all
     correct data splits. It particularly interprets the following elements of the config:
 
-     * `loaders`: the :class:`~mml.core.data_loading.modality_loaders.ModalityLoader`s
+     * `loaders`: the :class:`~mml.core.data_loading.modality_loaders.ModalityLoader` s
      * `preprocessing`: the :class:`~mml.core.data_loading.augmentations.augmentation_module.AugmentationModule`
      * `augmentations`: also :class:`~mml.core.data_loading.augmentations.augmentation_module.AugmentationModule`
      * all aspects with respect to sampling and the dataloader
@@ -104,7 +104,7 @@ class MultiTaskDataModule(lightning.LightningDataModule):
     def setup(self, stage: str) -> None:
         """
         Implements the lightning interface to prepare the datamodule. In particular sets up the
-        :class:`~mml.core.data_loading.task_dataset.TaskDataset`s
+        :class:`~mml.core.data_loading.task_dataset.TaskDataset` s
 
         :param stage:
         :return:

--- a/src/mml/core/data_preparation/task_creator.py
+++ b/src/mml/core/data_preparation/task_creator.py
@@ -212,10 +212,11 @@ class TaskCreator:
             `Modality.SAMPLE_ID` is required and the corresponding value has to be unique.
             Some further potential entries are `Modality.CLASS` with `int` value,
             and `Modality.MASK` with Path to some (greyscale) image, both with vals in idx_to_class.
-        :param Optional[List[SampleDescription]] test_iterator:
-            test data iterator, same type as train_iterator
-        :param Optional[List[SampleDescription]] unlabeled_iterator:
-            unlabeled data iterator, same type as train_iterator
+        :param Optional[List[SampleDescription]] test_iterator: test data iterator, same type as train_iterator, note
+            that MML expects test data to include labels (!), any label-free data is provided with unlabeled_iterator
+        :param Optional[List[SampleDescription]] unlabeled_iterator: unlabeled data iterator, same type as
+            train_iterator, can be used to either provide additional unlabeled "train data" or alternatively as
+            prediction data
         :param Optional[Dict[int, str]] idx_to_class: dict mapping ints to class names (e.g.
             {0 -> background, 1 -> instrument}), may also be non-continuous (e.g. {0 -> background, 3 -> instrument})
             for subclassing or mapping indices to the same class (e.g.

--- a/src/mml/core/models/lightning_single_frame.py
+++ b/src/mml/core/models/lightning_single_frame.py
@@ -59,7 +59,7 @@ class SingleFrameLightningModule(lightning.LightningModule):
         """
         The default MML lightning module supporting frame wise training and inference.
 
-        :param List[TaskStruct] task_structs: :class:`~mml.core.data_loading:task_struct:TaskStruct` for all tasks that
+        :param List[TaskStruct] task_structs: :class:`~mml.core.data_loading.task_struct.TaskStruct` for all tasks that
             the model shall interact upon
         :param DictConfig cfg: the main config file, will use multiple config groups (e.g., arch, loss, sampling,
             logging, tta, metrics, ..)
@@ -105,6 +105,9 @@ class SingleFrameLightningModule(lightning.LightningModule):
                     logger.info(f"Task {name} was not yet present in model heads and was added now.")
         else:
             self.model: BaseModel = hydra.utils.instantiate(self.cfg.arch)
+            if self.cfg.peft._target_:
+                peft_cfg = hydra.utils.instantiate(self.cfg.peft)
+                self.model.set_peft(peft_cfg)
             for struct in self.task_structs.values():
                 self.model.add_head(task_struct=struct)
         # construct criterion

--- a/src/mml/core/models/lightning_single_frame.py
+++ b/src/mml/core/models/lightning_single_frame.py
@@ -6,6 +6,7 @@
 
 import logging
 import warnings
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 import hydra.utils
@@ -29,6 +30,7 @@ from mml.core.data_loading.task_attributes import Modality, TaskType
 from mml.core.data_loading.task_dataset import TaskDataset
 from mml.core.data_loading.task_struct import TaskStruct
 from mml.core.models.merger import PredictionMerger
+from mml.core.models.torch_base import BaseModel
 from mml.core.scripts.exceptions import MMLMisconfigurationException
 from mml.core.scripts.utils import LearningPhase
 from mml.core.visualization.cm import render_confusion_matrix
@@ -47,28 +49,64 @@ CONFIGS_ROUTES = {
 
 
 class SingleFrameLightningModule(lightning.LightningModule):
-    """
-    The default MML lightning module supporting frame wise training and inference.
-    """
+    def __init__(
+        self,
+        task_structs: List[TaskStruct],
+        cfg: DictConfig,
+        task_weights: Optional[List[float]] = None,
+        load_parameters: Optional[Path] = None,
+    ):
+        """
+        The default MML lightning module supporting frame wise training and inference.
 
-    def __init__(self, task_structs: List[TaskStruct], cfg: DictConfig, weights: Optional[List[float]] = None):
+        :param List[TaskStruct] task_structs: :class:`~mml.core.data_loading:task_struct:TaskStruct` for all tasks that
+            the model shall interact upon
+        :param DictConfig cfg: the main config file, will use multiple config groups (e.g., arch, loss, sampling,
+            logging, tta, metrics, ..)
+        :param Optional[List[float]] task_weights: if provided this determines a specific weighting of tasks for the
+            loss, if `None` all tasks contribute equally
+        :param Optional[Path] load_parameters: if given will load model and weights, this ignores the current `cfg.arch`
+            and if any of the task_structs has already a model head with the loaded model it will be reused (otherwise
+            a new head is created for every task)
+        """
         super(SingleFrameLightningModule, self).__init__()
         # save hyperparameters
         self.save_hyperparameters()
         self.cfg = cfg
-        if weights is None:
-            weights = [1.0] * len(task_structs)
-        if len(task_structs) != len(weights):
-            raise ValueError(f"Number of weights ({len(weights)} does not match number of tasks {len(task_structs)}.")
-        self.weights = torch.as_tensor(weights)
+        if task_weights is None:
+            task_weights = [1.0] * len(task_structs)
+        if len(task_structs) != len(task_weights):
+            raise ValueError(
+                f"Number of task_weights ({len(task_weights)} does not match number of tasks {len(task_structs)}."
+            )
+        self.weights = torch.as_tensor(task_weights)
         self.task_structs = {struct.name: struct for struct in task_structs}
         self.targets: Dict[str, str] = {  # type: ignore
             name: struct.target.value for name, struct in self.task_structs.items() if struct.target is not None
         }
         # construct model
-        self.model = hydra.utils.instantiate(self.cfg.arch)
-        for struct in self.task_structs.values():
-            self.model.add_head(task_struct=struct)
+        if load_parameters is not None:
+            # for backward compatibility: make sure to handle previous stored lightning checkpoints
+            if load_parameters.suffix != ".mml":
+                warnings.warn(
+                    "You are loading a legacy model checkpoint. Full support of all features may not be "
+                    "guaranteed. MML will try to continue nevertheless."
+                )
+                # a bit cumbersome, we have to fully load the lightning module but discard everything except the model
+                self.model: BaseModel = SingleFrameLightningModule.load_from_checkpoint(load_parameters).model
+            else:
+                self.model = BaseModel.load_checkpoint(load_parameters)
+            # ensure compatibility with current task structs and existing heads
+            for name, struct in self.task_structs.items():
+                if name in self.model.heads:
+                    logger.info(f"Task {name} already present in model heads.")
+                else:
+                    self.model.add_head(task_struct=struct)
+                    logger.info(f"Task {name} was not yet present in model heads and was added now.")
+        else:
+            self.model: BaseModel = hydra.utils.instantiate(self.cfg.arch)
+            for struct in self.task_structs.values():
+                self.model.add_head(task_struct=struct)
         # construct criterion
         self.criteria = self.get_criteria()
         # construct metrics
@@ -248,7 +286,7 @@ class SingleFrameLightningModule(lightning.LightningModule):
         :param Dict[str, torch.Tensor] logits: logits as provided by model :meth:step
         :param Dict[str, torch.Tensor] targets: targets as provided by :meth:step
         :param LearningPhase phase: may be either train, val or test, used to access underlying
-            :class:~mml.core.data_loading:task_dataset:TaskDataset and as a logging prefix
+            :class:`~mml.core.data_loading:task_dataset:TaskDataset` and as a logging prefix
         :return:
         """
         if self.is_tuning:

--- a/src/mml/core/models/timm.py
+++ b/src/mml/core/models/timm.py
@@ -60,7 +60,7 @@ class TimmGenericModel(BaseModel):
         )
 
     def supports(self, task_type: TaskType) -> bool:
-        """TimmModel support classification tasks."""
+        """TimmModel supports classification and regression tasks."""
         return task_type in [TaskType.CLASSIFICATION, TaskType.MULTILABEL_CLASSIFICATION, TaskType.REGRESSION]
 
 

--- a/src/mml/core/models/torch_base.py
+++ b/src/mml/core/models/torch_base.py
@@ -148,7 +148,9 @@ class BaseModel(torch.nn.Module, ABC):
     @staticmethod
     def load_checkpoint(param_path: Union[Path, str]) -> "BaseModel":
         """
-        Load from a checkpoint.
+        Load from a checkpoint. Be aware that MML uses its own checkpoint structure (different from the one in
+        `lightning <https://github.com/Lightning-AI/lightning>`_). Detail can be found in
+        :meth:`~mml.core.models.torch_base.BaseModel.save_checkpoint`.
 
         :param Union[Path, str] param_path: path to load checkpoint from
         :return:
@@ -161,7 +163,7 @@ class BaseModel(torch.nn.Module, ABC):
             head = model._create_head(**init_kwargs)
             model.heads[head_name] = head
             head.load_state_dict(state[head_name])
-        logger.info("Loaded checkpoint!")
+        logger.info("Loaded MML checkpoint!")
         logger.debug(f"@ {param_path}")
         return model
 

--- a/src/mml/core/models/torch_base.py
+++ b/src/mml/core/models/torch_base.py
@@ -22,8 +22,8 @@ from transformers import Conv1D
 
 from mml.core.data_loading.task_attributes import RGBInfo, TaskType
 from mml.core.data_loading.task_struct import TaskStruct
-from mml.core.scripts.exceptions import MMLMisconfigurationException
 from mml.core.scripts.decorators import beta
+from mml.core.scripts.exceptions import MMLMisconfigurationException
 
 logger = logging.getLogger(__name__)
 
@@ -154,7 +154,7 @@ class BaseModel(torch.nn.Module, ABC):
         logger.debug(f"Unfroze {len(self._frozen_params)} params of model.")
         self._frozen_params = []
 
-    @beta('PEFT integration is still in beta.')
+    @beta("PEFT integration is still in beta.")
     def set_peft(self, peft_cfg: PeftConfig) -> None:
         """
         Applies a PEFT (Parameter Efficient FineTuning) method to the model. Usually this will lead to adapters injected

--- a/src/mml/core/models/torch_base.py
+++ b/src/mml/core/models/torch_base.py
@@ -23,6 +23,7 @@ from transformers import Conv1D
 from mml.core.data_loading.task_attributes import RGBInfo, TaskType
 from mml.core.data_loading.task_struct import TaskStruct
 from mml.core.scripts.exceptions import MMLMisconfigurationException
+from mml.core.scripts.decorators import beta
 
 logger = logging.getLogger(__name__)
 
@@ -153,6 +154,7 @@ class BaseModel(torch.nn.Module, ABC):
         logger.debug(f"Unfroze {len(self._frozen_params)} params of model.")
         self._frozen_params = []
 
+    @beta('PEFT integration is still in beta.')
     def set_peft(self, peft_cfg: PeftConfig) -> None:
         """
         Applies a PEFT (Parameter Efficient FineTuning) method to the model. Usually this will lead to adapters injected

--- a/src/mml/core/models/torch_base.py
+++ b/src/mml/core/models/torch_base.py
@@ -12,10 +12,17 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
 import hydra.utils
+import peft
 import torch
+from humanize import intword
+from peft import LoraConfig
+from peft.config import PeftConfig
+from sqlalchemy.testing.plugin.plugin_base import warnings
+from transformers import Conv1D
 
 from mml.core.data_loading.task_attributes import RGBInfo, TaskType
 from mml.core.data_loading.task_struct import TaskStruct
+from mml.core.scripts.exceptions import MMLMisconfigurationException
 
 logger = logging.getLogger(__name__)
 
@@ -43,6 +50,7 @@ class BaseModel(torch.nn.Module, ABC):
         # store init kwargs
         self._init_kwargs: Dict[str, Any] = kwargs  # stores stuff that needs to be persistent when re-initializing
         self._head_init_kwargs: List[Dict[str, Any]] = []  # stores init kwargs of heads
+        self._peft_kwargs: Dict[str, Any] = {}  # stores any peft kwargs
         # actually init backbone
         self._init_model(**kwargs)
         logger.debug("Model initialised.")
@@ -145,6 +153,54 @@ class BaseModel(torch.nn.Module, ABC):
         logger.debug(f"Unfroze {len(self._frozen_params)} params of model.")
         self._frozen_params = []
 
+    def set_peft(self, peft_cfg: PeftConfig) -> None:
+        """
+        Applies a PEFT (Parameter Efficient FineTuning) method to the model. Usually this will lead to adapters injected
+        to the base model that complement existing weights. The advantage is that the majority of existing weights is
+        frozen (the .requires_grad attribute of the tensors is set to false) while only the smaller adapters are kept
+        trainable.
+
+        :param PeftConfig peft_cfg: PEFTConfig instance, see
+            `huggingface/peft <https://github.com/huggingface/peft/tree/main>`_
+        :return: None, since model is mofified in place
+        """
+        if self._peft_kwargs:
+            raise RuntimeError("PEFT already set for this model!")
+        if self._frozen_params:
+            warnings.warn(
+                "Backbone was frozen prior to applying PEFT, will first unfreeze backbone and then apply."
+                "You may re-freeze the backbone (i.e. the injected adapters)."
+            )
+            self.unfreeze_backbone()
+        if peft_cfg.is_prompt_learning or peft_cfg.is_adaption_prompt:
+            raise MMLMisconfigurationException(f"Applying {peft_cfg.peft_type} is likely an unsupported PEFT type.")
+        self._peft_kwargs = peft_cfg.to_dict()
+        if isinstance(peft_cfg, LoraConfig) and peft_cfg.target_modules == "auto":
+            peft_cfg.target_modules = self.get_lora_compatible_layers(self.backbone)
+            logger.info(f"Auto detected {len(peft_cfg.target_modules)} compatible layers for LoRa in model backbone.")
+        pre_params = self.count_parameters(only_trainable=True)["backbone"]
+        self.backbone = peft.get_peft_model(model=self.backbone, peft_config=peft_cfg)
+        post_params = self.count_parameters(only_trainable=True)["backbone"]
+        logger.info(
+            f"After applying {peft_cfg.peft_type} from {intword(pre_params)} params only {intword(post_params)}"
+            f" remain trainable (={post_params / pre_params:.2%})."
+        )
+
+    @staticmethod
+    def get_lora_compatible_layers(backbone: torch.nn.Module) -> List[str]:
+        """
+        Helper function to extract all Lora compatible layers (from the peft library).
+
+        :param torch.nn.Module backbone: the model to extract layers from
+        :return: list of strings the correspond to the respective layer names
+        """
+        layer_names = []
+        for name, module in backbone.named_modules():
+            # these are the currently LORA supported layers
+            if isinstance(module, (torch.nn.Linear, torch.nn.Embedding, torch.nn.Conv2d, Conv1D)):
+                layer_names.append(name)
+        return layer_names
+
     @staticmethod
     def load_checkpoint(param_path: Union[Path, str]) -> "BaseModel":
         """
@@ -157,6 +213,10 @@ class BaseModel(torch.nn.Module, ABC):
         """
         state = torch.load(param_path, weights_only=False)
         model: BaseModel = hydra.utils.instantiate(dict(_target_=state["__target__"], **state["__init_kwargs__"]))
+        # for backward compatibility we check whether the keyword is present in the state
+        if "__peft_kwargs__" in state and len(state["__peft_kwargs__"]) > 0:
+            peft_cfg = PeftConfig.from_peft_type(**state["__peft_kwargs__"])
+            model.set_peft(peft_cfg)
         model.backbone.load_state_dict(state["backbone"])  # type: ignore[union-attr]
         model._frozen_params = state["__frozen_params__"]
         for head_name, init_kwargs in zip(state["__head_names__"], state["__head_init_kwargs__"]):
@@ -183,6 +243,7 @@ class BaseModel(torch.nn.Module, ABC):
                 "__target__": self.__class__,
                 "__frozen_params__": self._frozen_params,
                 "__head_init_kwargs__": self._head_init_kwargs,
+                "__peft_kwargs__": self._peft_kwargs,
             }
         )
         torch.save(state, param_path)

--- a/src/mml/core/scripts/callbacks.py
+++ b/src/mml/core/scripts/callbacks.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any, Dict, List
 
 import lightning
+import lightning.pytorch.tuner.lr_finder
 import torch
 from lightning.pytorch.callbacks import ModelCheckpoint, RichProgressBar, TQDMProgressBar
 

--- a/src/mml/core/scripts/pipeline_configuration.py
+++ b/src/mml/core/scripts/pipeline_configuration.py
@@ -131,6 +131,7 @@ PIPELINE_CONFIG_PARTS = [
     "lr_scheduler",
     "mode",
     "optimizer",
+    "peft",
     "preprocessing",
     "sampling",
     "trainer",

--- a/src/mml/core/scripts/schedulers/base_scheduler.py
+++ b/src/mml/core/scripts/schedulers/base_scheduler.py
@@ -311,7 +311,8 @@ class AbstractBaseScheduler(metaclass=abc.ABCMeta):
             hydra_cfg = HydraConfig.get()
         except ValueError:
             hydra_cfg = None
-        if hydra_cfg:
+        # check preprocessing ID (only available if not in continue mode as runtime choices may deviate)
+        if hydra_cfg and not self.continue_status:
             choices = OmegaConf.to_container(hydra_cfg.runtime.choices)
             if Path(choices["preprocessing"]).stem != self.cfg.preprocessing.id:
                 raise MMLMisconfigurationException(

--- a/src/mml/core/scripts/schedulers/base_scheduler.py
+++ b/src/mml/core/scripts/schedulers/base_scheduler.py
@@ -379,17 +379,37 @@ class AbstractBaseScheduler(metaclass=abc.ABCMeta):
 
     def after_preparation_hook(self) -> None:
         """
-        This hook is usually used if the scheduler itself contains data that is
-        modified across subroutines. To ensure the capability to use the continue flag, this routine may search for
-        a dumped version and load it. See mml.task_similarity.scripts.abstract_task_distance_scheduler for an example
-        usage.
+        This hook will be called at the end of the :meth:`prepare_exp` step. That step basically prepares the task
+        structs accordingly. Once this is done, this hook can be used for remaining setups necessary that rely on
+        task structs (e.g. compatibility checks).
+
+        In contrast to the other scheduler steps in the schedule, the :meth:`prepare_exp` is also performed in
+        CONTINUE mode. This hook can be used to ensure continue capability of the scheduler, e.g., by loading
+        additional ressources from previous runs. More on CONTINUE mode: :ref:`continue-option`
+
+        Example usages:
+
+         * :meth:`~mml.core.scripts.schedulers.postprocess_scheduler.PostprocessScheduler.after_preparation_hook`
+         * :meth:`~mml.core.scripts.schedulers.preprocess_scheduler.PreprocessScheduler.after_preparation_hook`
+         * :meth:`~mml_similarity.scripts.abstract_task_distance_scheduler.AbstractTaskDistanceScheduler.after_preparation_hook`
         """
         pass
 
     def before_finishing_hook(self):
         """
-        Final hook at the end of an experiment, depending on the subroutines executed. Example could be some results
-        plotting. See mml_similarity.scripts.abstract_task_distance_scheduler for an example usage.
+        This hook will be called at the beginning of the :meth:`finish_exp` step. That step performs dumping and clean
+        up of intermediates. As such this hook is the perfect opportunity to aggregate results or other intermediates
+        from the previous computing steps (e.g., some results plotting).
+
+        It is also ideally placed to set the :attr:`return_value` of the scheduler, which will be returned by the
+        :meth:`run` method and can be used for experiment evaluation and in hyperparameter optimization (see
+        :doc:`/hpo`).
+
+        Example usages:
+
+         * :meth:`~mml.core.scripts.schedulers.postprocess_scheduler.PostprocessScheduler.after_preparation_hook`
+         * :meth:`~mml.core.scripts.schedulers.preprocess_scheduler.PreprocessScheduler.after_preparation_hook`
+         * :meth:`~mml_similarity.scripts.abstract_task_distance_scheduler.AbstractTaskDistanceScheduler.after_preparation_hook`
         """
         pass
 

--- a/src/mml/core/scripts/schedulers/info_scheduler.py
+++ b/src/mml/core/scripts/schedulers/info_scheduler.py
@@ -76,9 +76,6 @@ class InfoScheduler(AbstractBaseScheduler):
             self.commands.append(self.info_models)
             self.params.append([])
 
-    def after_preparation_hook(self):
-        pass
-
     def before_finishing_hook(self):
         logger.info(f"Total number of all samples: {self.total_sample_sum}.")
 

--- a/src/mml/core/scripts/schedulers/postprocess_scheduler.py
+++ b/src/mml/core/scripts/schedulers/postprocess_scheduler.py
@@ -230,7 +230,7 @@ class PostprocessScheduler(AbstractBaseScheduler):
             f"Will perform ensemble selection based on {len(eval_ids)} samples from test split "
             f"({len(eval_ids) / len(all_test_ids):.2%})."
         )
-        # use the loss function with optional class weights, but need to ensure no unintended weighing is performed
+        # use the loss function with optional class weights, but need to ensure no unintended weighting is performed
         with omegaconf.open_dict(self.cfg):
             self.cfg.sampling.balanced = False
             self.cfg.loss.auto_activate_weighing = False

--- a/src/mml/core/scripts/schedulers/transfer_scheduler.py
+++ b/src/mml/core/scripts/schedulers/transfer_scheduler.py
@@ -6,6 +6,7 @@
 
 import logging
 import random
+import warnings
 
 import lightning
 import torch
@@ -103,12 +104,12 @@ class TransferScheduler(TrainingScheduler):
         else:
             # new loading logic for MML checkpoints
             new_module = self.create_model(
-                task_structs=module.task_structs,
-                task_weights=module.weights.tolist(),
+                task_structs=model.task_structs,
+                task_weights=model.weights.tolist(),
                 load_parameters=storage.parameters,
             )
             # replace model
-            module.model = new_module.model
+            model.model = new_module.model
         logger.info(f"Successfully loaded pretrain weights from task {self.cfg.mode.pretrain_task}.")
         if self.cfg.mode.freeze:
             model.model.freeze_backbone()

--- a/src/mml/core/scripts/schedulers/upgrade_scheduler.py
+++ b/src/mml/core/scripts/schedulers/upgrade_scheduler.py
@@ -80,7 +80,7 @@ class UpgradeScheduler(AbstractBaseScheduler):
     def prepare_exp(self) -> None:
         """
         Prepare experiment expects tasks to be present and loads these into task factory container. Here this should
-        be avoided.
+        be avoided (including :meth:`after_preparation_hook`).
         """
         logger.debug("Skipping experiment setup!")
 

--- a/src/mml/core/scripts/utils.py
+++ b/src/mml/core/scripts/utils.py
@@ -124,7 +124,7 @@ def load_env() -> None:
     if dotenv_path.exists():
         load_dotenv(dotenv_path=dotenv_path)
         # as long as the default system (=local) is used, check for the minimum env variables
-        if not any(cli_arg.startswith('sys=') for cli_arg in sys.argv):
+        if not any(cli_arg.startswith("sys=") for cli_arg in sys.argv):
             if not Path(os.getenv("MML_DATA_PATH")).exists():
                 raise MMLMisconfigurationException("Invalid MML_DATA_PATH, have you modified the mml.env entry?")
             if not Path(os.getenv("MML_RESULTS_PATH")).exists():

--- a/src/mml/core/scripts/utils.py
+++ b/src/mml/core/scripts/utils.py
@@ -123,16 +123,16 @@ def load_env() -> None:
         logger.debug(f"No MML_ENV_PATH provided, will try to load env variables from default path ({dotenv_path}).")
     if dotenv_path.exists():
         load_dotenv(dotenv_path=dotenv_path)
-        if not Path(os.getenv("MML_DATA_PATH")).exists():
-            raise MMLMisconfigurationException("Invalid MML_DATA_PATH, have you modified the mml.env entry?")
-        if not Path(os.getenv("MML_RESULTS_PATH")).exists():
-            raise MMLMisconfigurationException("Invalid MML_RESULTS_PATH, have you modified the mml.env entry?")
-        try:
-            _ = int(os.getenv("MML_LOCAL_WORKERS"))
-        except ValueError:
-            raise MMLMisconfigurationException("Invalid MML_LOCAL_WORKERS, have you modified the mml.env entry?")
-        if not Path(os.getenv("MML_DATA_PATH")).exists():
-            raise MMLMisconfigurationException("Invalid MML_DATA_PATH, have you modified the mml.env entry?")
+        # as long as the default system (=local) is used, check for the minimum env variables
+        if not any(cli_arg.startswith('sys=') for cli_arg in sys.argv):
+            if not Path(os.getenv("MML_DATA_PATH")).exists():
+                raise MMLMisconfigurationException("Invalid MML_DATA_PATH, have you modified the mml.env entry?")
+            if not Path(os.getenv("MML_RESULTS_PATH")).exists():
+                raise MMLMisconfigurationException("Invalid MML_RESULTS_PATH, have you modified the mml.env entry?")
+            try:
+                _ = int(os.getenv("MML_LOCAL_WORKERS"))
+            except ValueError:
+                raise MMLMisconfigurationException("Invalid MML_LOCAL_WORKERS, have you modified the mml.env entry?")
     else:
         raise MMLMisconfigurationException(
             f".env file not found at {dotenv_path}! Please follow the documentation instructions to setup MML."

--- a/src/mml/testing/boring_model.py
+++ b/src/mml/testing/boring_model.py
@@ -1,0 +1,50 @@
+from typing import Any, Dict
+
+import torch
+import torch.nn
+
+from mml.core.data_loading.task_attributes import TaskType
+from mml.core.models.torch_base import BaseHead, BaseModel
+
+
+class BoringModel(BaseModel):
+    """
+    A simple model that just processes a single pixel per image.
+    """
+
+    def forward_features(self, x: torch.Tensor) -> torch.Tensor:
+        batch_size = x.shape[0]
+        # create indexing tuple: ([0, 1, ..., B-1], 0, 0, ...)
+        indices = [torch.arange(batch_size)]
+        indices.extend([0] * (x.ndim - 1))
+        # extract values and reshape to (B, 1)
+        return self.backbone(x[tuple(indices)].unsqueeze(1))
+
+    def forward(self, x: torch.Tensor) -> Dict[str, torch.Tensor]:
+        features = self.forward_features(x)
+        return {name: head(features) for name, head in self.heads.items()}
+
+    def _init_model(self, **kwargs) -> None:
+        self.backbone = torch.nn.Linear(in_features=1, out_features=1)
+
+    def _create_head(self, task_type: TaskType, num_classes: int, **kwargs: Any) -> BaseHead:
+        return BoringHead(task_type=task_type, num_classes=num_classes, drop_rate=0.1)
+
+    def supports(self, task_type: TaskType) -> bool:
+        """BoringModel supports classification and regression tasks."""
+        return task_type in [TaskType.CLASSIFICATION, TaskType.MULTILABEL_CLASSIFICATION, TaskType.REGRESSION]
+
+
+class BoringHead(BaseHead):
+    def __init__(self, task_type: TaskType, num_classes: int, drop_rate: float):
+        super().__init__(task_type=task_type, num_classes=num_classes)
+        self.drop = torch.nn.Dropout(drop_rate)
+        # only a single head for regression tasks
+        n_heads = 1 if task_type == TaskType.REGRESSION else num_classes
+        self.linear = torch.nn.Linear(1, n_heads, bias=True)
+        torch.nn.init.xavier_uniform_(self.linear.weight)
+        torch.nn.init.constant_(self.linear.bias, 0)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.drop(x)
+        return self.linear(x)

--- a/src/mml/testing/fixtures.py
+++ b/src/mml/testing/fixtures.py
@@ -130,12 +130,12 @@ def dummy_fake_pipeline_path():
 
 
 @pytest.fixture
-def image():
+def image() -> np.ndarray:
     return np.random.randint(low=0, high=256, size=(100, 100, 3), dtype=np.uint8)
 
 
 @pytest.fixture
-def mask():
+def mask() -> np.ndarray:
     return np.random.randint(low=0, high=2, size=(100, 100), dtype=np.uint8)
 
 

--- a/tests/performance/test_training_speed.py
+++ b/tests/performance/test_training_speed.py
@@ -14,9 +14,19 @@ from mml.core.scripts.schedulers.train_scheduler import TrainingScheduler
 @pytest.mark.benchmark(group="training_epoch")
 def test_training_speed(mml_config, benchmark, file_manager, fake_task):
     OmegaConf.set_struct(mml_config, False)
-    mml_config.mode.subroutines = ["train_fold"]
-    mml_config.pivot.name = ["mml_fake_task"]
+    mml_config.mode.subroutines = ["train"]
+    mml_config.pivot.name = "mml_fake_task"
+    mml_config.mode.cv = False
+    mml_config.mode.nested = False
+    mml_config.mode.multitask = False
+    mml_config.mode.store_parameters = False
+    mml_config.mode.use_blueprint = False
+    mml_config.mode.pipeline_keys = None
+    mml_config.mode.store_best = True
+    mml_config.mode.eval_on = None
+    mml_config.mode.task_weights = None
     mml_config.trainer.max_epochs = 1
+    OmegaConf.set_struct(mml_config, True)
 
     scheduler = TrainingScheduler(mml_config)
     scheduler.prepare_exp()

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -5,12 +5,12 @@
 #
 
 import pytest
-from lightning.pytorch.callbacks import ModelCheckpoint
 from omegaconf import OmegaConf
 
 from mml.core.data_loading.task_attributes import Keyword, Modality, RGBInfo, Sizes, TaskType
 from mml.core.data_loading.task_struct import TaskStruct
 from mml.core.scripts.model_storage import ModelStorage
+from mml.testing.boring_model import BoringModel
 
 
 @pytest.fixture()
@@ -32,7 +32,7 @@ def dummy_task_struct():
 
 @pytest.fixture()
 def dummy_model_storage(file_manager, dummy_task_struct):
-    par_path = file_manager.construct_saving_path(ModelCheckpoint(), key="parameters", task_name=dummy_task_struct.name)
+    par_path = file_manager.construct_saving_path(BoringModel(), key="parameters", task_name=dummy_task_struct.name)
     pip_path = file_manager.construct_saving_path(
         obj=OmegaConf.create({}), key="pipeline", task_name=dummy_task_struct.name
     )

--- a/tests/unit/core/data_loading/test_task_struct.py
+++ b/tests/unit/core/data_loading/test_task_struct.py
@@ -7,13 +7,13 @@
 from pathlib import Path
 
 import pytest
-from lightning.pytorch.callbacks import ModelCheckpoint
 from omegaconf import OmegaConf
 
 from mml.core.data_loading.task_struct import TaskStruct, undup_names
 from mml.core.scripts.exceptions import TaskNotFoundError
 from mml.core.scripts.model_storage import ModelStorage
 from mml.core.scripts.utils import ARG_SEP, TAG_SEP
+from mml.testing.boring_model import BoringModel
 
 
 def test_paths_representation(dummy_task_struct):
@@ -28,7 +28,7 @@ def test_paths_representation(dummy_task_struct):
 
 def test_models_representation(dummy_task_struct, file_manager):
     attr = TaskStruct.non_permanent_task_attributes()
-    par_path = file_manager.construct_saving_path(ModelCheckpoint(), key="parameters", task_name=dummy_task_struct.name)
+    par_path = file_manager.construct_saving_path(BoringModel(), key="parameters", task_name=dummy_task_struct.name)
     pip_path = file_manager.construct_saving_path(
         obj=OmegaConf.create({}), key="pipeline", task_name=dummy_task_struct.name
     )

--- a/tests/unit/core/models/test_base_model.py
+++ b/tests/unit/core/models/test_base_model.py
@@ -1,0 +1,15 @@
+from mml.core.models.torch_base import BaseModel
+from mml.testing.boring_model import BoringModel
+
+
+def test_save_load(tmp_path, test_task_monkeypatch):
+    tmp_path /= "model.mml"
+    model = BoringModel()
+    model.add_head(test_task_monkeypatch["test_task_a"])
+    model.freeze_backbone()
+    model.save_checkpoint(tmp_path)
+    loaded_model = BaseModel.load_checkpoint(tmp_path)
+    assert isinstance(loaded_model, BoringModel)
+    assert "test_task_a" in loaded_model.heads
+    assert loaded_model._frozen_params == model._frozen_params
+    assert loaded_model.count_parameters(only_trainable=False) == model.count_parameters(only_trainable=False)

--- a/tests/unit/core/models/test_timm.py
+++ b/tests/unit/core/models/test_timm.py
@@ -6,6 +6,7 @@
 
 import pytest
 import torch
+from peft import LoraConfig
 
 from mml.core.data_loading.task_attributes import Modality, RGBInfo, Sizes, TaskType
 from mml.core.data_loading.task_struct import TaskStruct
@@ -82,3 +83,13 @@ def test_timm_count_parameters(model_name, dummy_task_struct):
     model.freeze_backbone()
     assert model.count_parameters()["backbone"] == 0
     assert model.count_parameters(only_trainable=False)["backbone"] > 0
+
+
+@pytest.mark.parametrize("model_name", ["resnet18", "vit_tiny_patch16_224.augreg_in21k"])
+def test_timm_peft(model_name):
+    lora_cfg = LoraConfig(r=8, target_modules="auto")
+    model = TimmGenericModel(name=model_name, pretrained=True, drop_rate=0.5)
+    model.set_peft(peft_cfg=lora_cfg)
+    c, h, w = model.input_size
+    t = torch.rand(1, c, h, w)
+    _ = model(t)


### PR DESCRIPTION
Adds two major features and some minor fixes & doc improvements.

Restorable models:
> Model storing now relies on the MML format (defined in `src/mml/core/models/torch_base.py`) instead of the `lightning` one

PEFT integration:
> Drastically reduce the number of trainable parameters by leveraging the `huggingface/peft` library, integrating smoothly with MML 